### PR TITLE
タイトルページコンポーネントを分割

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,14 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { TitlePage } from "./presentation/pages/Title";
 import { MatchPage } from "./presentation/pages/Match";
-import TitlePage from "./presentation/pages/Title";
 
 export function App() {
   return (
     <>
       <BrowserRouter>
         <Routes>
-          <Route path="/match" element={<MatchPage />} />
           <Route path="/" element={<TitlePage />} />
+          <Route path="/match" element={<MatchPage />} />
         </Routes>
       </BrowserRouter>
     </>

--- a/src/presentation/components/share/Header.tsx
+++ b/src/presentation/components/share/Header.tsx
@@ -1,0 +1,13 @@
+export const Header = () => {
+  return (
+    <>
+      <div className="hidden absolute top-4 left-4 md:block items-center">
+        <img
+          src="/Drump.png"
+          alt="Drump Logo"
+          className="size-32 object-contain"
+        />
+      </div>
+    </>
+  );
+};

--- a/src/presentation/components/title/Hero.tsx
+++ b/src/presentation/components/title/Hero.tsx
@@ -1,0 +1,42 @@
+export const Hero = () => {
+  return (
+    <>
+      <div className="max-w-3xl space-y-4">
+        <div className="relative inline-block z-0 w-full -space-y-3 md:-space-y-6">
+          <h1
+            className="
+              text-5xl md:text-6xl xl:text-7xl text-black font-['Dela_Gothic_One'] [-webkit-text-stroke:3px_#fff462]
+              before:md:block before:md:content-[''] before:md:absolute before:w-full
+              before:md:h-10 before:md:bg-black before:md:mt-6 before:md:-z-10
+              after:md:block after:md:content-[''] after:md:absolute after:md:w-full
+            after:md:bg-black after:md:-mt-2 after:md:-z-10 after:md:border-solid
+              after:md:border-t-[12px] after:md:border-t-black
+              after:md:border-l-[16px] after:md:border-l-white
+              after:md:border-r-[16px] after:md:border-r-white
+            "
+          >
+            BLACK
+          </h1>
+          <h1
+            className="
+              text-5xl md:text-6xl xl:text-7xl text-black font-['Dela_Gothic_One'] [-webkit-text-stroke:3px_#fff462]
+              before:md:block before:md:content-[''] before:md:absolute before:md:w-full
+              before:md:h-9 before:md:bg-black before:md:mt-6 before:md:-z-10
+              after:md:block after:md:content-[''] after:md:absolute after:md:w-full
+            after:md:bg-black after:md:-mt-2 after:md:-z-10 after:md:border-solid
+              after:md:border-t-[12px] after:md:border-t-black
+              after:md:border-l-[16px] after:md:border-l-white
+              after:md:border-r-[16px] after:md:border-r-white
+            "
+          >
+            JACK
+          </h1>
+        </div>
+        <h3 className="text-base sm:text-xl md:text-2xl font-medium">
+          Welcome to the Black Jack game! <br />
+          Click the button below to start playing.
+        </h3>
+      </div>
+    </>
+  );
+};

--- a/src/presentation/components/title/TitleButton.tsx
+++ b/src/presentation/components/title/TitleButton.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+import { LucideIcon } from "lucide-react";
+
+import { cn } from "@/presentation/shadcnUI/lib/utils";
+import { Button } from "@/presentation/shadcnUI/components/ui/button";
+
+interface TitleButtonProps {
+  to: string;
+  text: string;
+  icon: LucideIcon;
+  buttonSize?: string;
+  direction?: string;
+  iconSize?: string;
+}
+
+export const TitleButton = ({
+  to,
+  text,
+  icon: Icon,
+  // 正方形のボタンを基準
+  buttonSize = "md:size-32",
+  direction = "flex-col",
+  iconSize = "size-20",
+}: TitleButtonProps) => {
+  return (
+    <>
+      <Button
+        className={cn(
+          "group relative py-6 px-10 w-40 transition hover:scale-110",
+          buttonSize
+        )}
+        asChild
+      >
+        <Link className={cn("flex", direction)} to={to}>
+          <Icon className={cn("hidden md:block", iconSize)} />
+          <span className="text-base md:text-xl">{text}</span>
+          <div className="absolute inset-0 flex h-full w-full justify-center [transform:skew(-15deg)_translateX(-100%)] group-hover:duration-1000 group-hover:[transform:skew(-12deg)_translateX(100%)]">
+            <div className="relative h-full w-8 bg-white/20" />
+          </div>
+        </Link>
+      </Button>
+    </>
+  );
+};

--- a/src/presentation/pages/Title.tsx
+++ b/src/presentation/pages/Title.tsx
@@ -1,103 +1,32 @@
-import { Link } from "react-router-dom";
 import { ArrowRight, Users, BookOpenText, ChartColumn } from "lucide-react";
 
-import { Button } from "@/presentation/shadcnUI/components/ui/button";
+import { Header } from "../components/share/Header";
+import { Hero } from "../components/title/Hero";
+import { TitleButton } from "../components/title/TitleButton";
 
-export default function TitlePage() {
+export const TitlePage = () => {
   return (
-    <main className="min-h-screen pt-20">
-      <div className="hidden absolute top-4 left-4 md:block items-center">
-        <img
-          src="/Drump.png"
-          alt="Drump Logo"
-          className="size-32 object-contain"
-        />
-      </div>
+    <main className="min-h-screen">
+      <Header />
 
-      <div className="min-h-full flex flex-col items-center justify-center md:justify-start text-center gap-y-4 flex-1 px-6 pb-10">
-        <div className="max-w-3xl space-y-4">
-          <div className="relative inline-block z-0 w-full -space-y-3 md:-space-y-6">
-            <h1
-              className="
-                            text-5xl md:text-6xl xl:text-7xl text-black font-['Dela_Gothic_One'] [-webkit-text-stroke:3px_#fff462]
-                            before:md:block before:md:content-[''] before:md:absolute before:w-full
-                            before:md:h-10 before:md:bg-black before:md:mt-6 before:md:-z-10
-                            after:md:block after:md:content-[''] after:md:absolute after:md:w-full
-                            after:md:bg-black after:md:-mt-2 after:md:-z-10 after:md:border-solid
-                            after:md:border-t-[12px] after:md:border-t-black
-                            after:md:border-l-[16px] after:md:border-l-white
-                            after:md:border-r-[16px] after:md:border-r-white
-                        "
-            >
-              BLACK
-            </h1>
-            <h1
-              className="
-                            text-5xl md:text-6xl xl:text-7xl text-black font-['Dela_Gothic_One'] [-webkit-text-stroke:3px_#fff462]
-                            before:md:block before:md:content-[''] before:md:absolute before:md:w-full
-                            before:md:h-9 before:md:bg-black before:md:mt-6 before:md:-z-10
-                            after:md:block after:md:content-[''] after:md:absolute after:md:w-full
-                            after:md:bg-black after:md:-mt-2 after:md:-z-10 after:md:border-solid
-                            after:md:border-t-[12px] after:md:border-t-black
-                            after:md:border-l-[16px] after:md:border-l-white
-                            after:md:border-r-[16px] after:md:border-r-white
-                        "
-            >
-              JACK
-            </h1>
-          </div>
-          <h3 className="text-base sm:text-xl md:text-2xl font-medium">
-            Welcome to the Black Jack game! <br />
-            Click the button below to start playing.
-          </h3>
-        </div>
-        <div className="flex flex-col space-y-4 md:space-y-8">
-          <div className="flex justify-center">
-            <Button className="group relative items-center justify-center overflow-hidden rounded-md py-6 px-10 w-40 md:w-48 font-medium text-neutral-200 transition hover:scale-110">
-              {/* TODO: スタートのパスを指定する */}
-              <Link className="flex flex-row" to="/#">
-                <span className="text-base md:text-2xl">スタート</span>
-                <ArrowRight className="hidden md:block size-8 ml-1 -mr-2" />
-                <div className="absolute inset-0 flex h-full w-full justify-center [transform:skew(-15deg)_translateX(-100%)] group-hover:duration-1000 group-hover:[transform:skew(-12deg)_translateX(100%)]">
-                  <div className="relative h-full w-8 bg-white/20" />
-                </div>
-              </Link>
-            </Button>
-          </div>
+      <div className="min-h-full flex flex-col items-center justify-center text-center gap-y-4 flex-1 px-6 pt-16 pb-10">
+        <Hero />
+        <div className="space-y-4 md:space-y-8">
+          <TitleButton
+            to="match-start"
+            text="スタート"
+            icon={ArrowRight}
+            buttonSize="md:w-48"
+            direction="flex-row-reverse"
+            iconSize="size-8"
+          />
           <div className="flex flex-col justify-center md:flex-row space-y-4 md:space-y-0 md:space-x-52">
-            <Button
-              className="py-6 px-10 md:size-32 transition hover:scale-110"
-              asChild
-            >
-              {/* TODO: スコアのパスを指定する */}
-              <Link className="flex flex-col" to="/#">
-                <ChartColumn className="hidden md:block size-20" />
-                <span className="text-sm md:text-xl">スコア</span>
-              </Link>
-            </Button>
-            <Button
-              className="py-6 px-10 md:size-32 transition hover:scale-110"
-              asChild
-            >
-              {/* TODO: プレイヤー登録のパスを指定する */}
-              <Link className="flex flex-col" to="/#">
-                <Users className="hidden md:block size-20" />
-                <span className="text-sm md:text-xl">プレイヤー登録</span>
-              </Link>
-            </Button>
-            <Button
-              className="py-6 px-10 md:size-32 transition hover:scale-110"
-              asChild
-            >
-              {/* TODO: 遊び方のパスを指定する */}
-              <Link className="flex flex-col" to="/#">
-                <BookOpenText className="hidden md:block size-20" />
-                <span className="text-sm md:text-xl">遊び方</span>
-              </Link>
-            </Button>
+            <TitleButton to="/scores" text="スコア" icon={ChartColumn} />
+            <TitleButton to="/users" text="プレイヤー登録" icon={Users} />
+            <TitleButton to="/rules" text="遊び方" icon={BookOpenText} />
           </div>
         </div>
       </div>
     </main>
   );
-}
+};


### PR DESCRIPTION
# やったこと
- タイトルページのエクポートをnamed exportに変更
- タイトルページコンポーネントを分割
  - とくにヘッダーはマッチページにも使用しようと思っているので、分割する必要があると考えた


# 参考

