### PR TITLE
match start page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-label": "^2.1.1",
+        "@radix-ui/react-scroll-area": "^1.2.2",
         "@radix-ui/react-slot": "^1.1.0",
         "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^4.3.3",
@@ -21,6 +22,7 @@
         "react": "^18.3.1",
         "react-card-flip": "^1.2.3",
         "react-dom": "^18.3.1",
+        "react-nice-avatar": "^1.5.0",
         "react-router-dom": "^7.0.1",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
@@ -285,7 +287,6 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
       "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -342,6 +343,23 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.23.1",
@@ -1018,6 +1036,11 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ=="
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
@@ -1082,6 +1105,20 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.0.tgz",
+      "integrity": "sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1241,6 +1278,36 @@
       "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
       "dependencies": {
         "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.2.tgz",
+      "integrity": "sha512-EFI1N/S3YxZEW/lJ/H1jY3njlvTd8tBmgKEn4GHi51+aMm94i6NmAJstsm5cu3yJwYqYc93gpCPm21FeAbFk6g==",
+      "dependencies": {
+        "@radix-ui/number": "1.1.0",
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2063,9 +2130,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.3.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.17.tgz",
-      "integrity": "sha512-opAQ5no6LqJNo9TqnxBKsgnkIYHozW9KSTlFVoSUJYh1Fl/sswkEoqIugRSm7tbh6pABtYjGAjW+GOS23j8qbw==",
+      "version": "18.3.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
+      "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2815,9 +2882,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001689",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001689.tgz",
-      "integrity": "sha512-CmeR2VBycfa+5/jOfnp/NpWPGd06nf1XYiefUvhXFfZE4GkRc9jv+eGPS4nT558WS/8lYCzV8SlANCIPvbWP1g==",
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
       "funding": [
         {
           "type": "opencollective",
@@ -2907,6 +2974,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/chroma-js": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-2.6.0.tgz",
+      "integrity": "sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A=="
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -3252,9 +3324,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.74",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.74.tgz",
-      "integrity": "sha512-ck3//9RC+6oss/1Bh9tiAVFy5vfSKbRHAFh7Z3/eTRkEqJeWgymloShB17Vg3Z4nmDNp35vAd1BZ6CMW4Wt6Iw=="
+      "version": "1.5.75",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.75.tgz",
+      "integrity": "sha512-Lf3++DumRE/QmweGjU+ZcKqQ+3bKkU/qjaKYhIJKEOhgIO9Xs6IiAQFkfFoj+RhgDk4LUeNsLo6plExHqSyu6Q=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3874,6 +3946,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4008,9 +4086,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.13.0.tgz",
-      "integrity": "sha512-49TewVEz0UxZjr1WYYsWpPrhyC/B/pA8Bq0fUmet2n+eR7yn0IvNzNaoBwnK6mdkzcN+se7Ez9zUgULTz2QH4g==",
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
+      "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -4178,6 +4256,17 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -4500,9 +4589,9 @@
       }
     },
     "node_modules/math-intrinsics": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.0.0.tgz",
-      "integrity": "sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "engines": {
         "node": ">= 0.4"
       }
@@ -4681,6 +4770,67 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-nailgun-client": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/node-nailgun-client/-/node-nailgun-client-0.1.2.tgz",
+      "integrity": "sha512-OC611lR0fsDUSptwnhBf8d3sj4DZ5fiRKfS2QaGPe0kR3Dt9YoZr1MY7utK0scFPTbXuQdSBBbeoKYVbME1q5g==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.8.1"
+      },
+      "bin": {
+        "node-nailgun-client": "index.js"
+      }
+    },
+    "node_modules/node-nailgun-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/node-nailgun-server": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/node-nailgun-server/-/node-nailgun-server-0.1.4.tgz",
+      "integrity": "sha512-e0Hbh6XPb/7GqATJ45BePaUEO5AwR7InRW/pGeMKHH1cqPMBFCeqdBNfvi+bkVLnsbYOOQE+pAek9nmNoD8sYw==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.8.1"
+      },
+      "bin": {
+        "node-nailgun-server": "index.js"
+      }
+    },
+    "node_modules/node-nailgun-server/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/node-plantuml": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/node-plantuml/-/node-plantuml-0.9.0.tgz",
+      "integrity": "sha512-bUnntTGjbpYu1pvXZI/GS6ctcXf3AOMqJxBMO8vFzTT5RwH8Cj/J5Ca6Dy+PEfMiMDdSBCFKSGnvYyBvYnucXg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "commander": "^2.8.1",
+        "node-nailgun-client": "^0.1.0",
+        "node-nailgun-server": "^0.1.4",
+        "plantuml-encoder": "^1.2.5"
+      },
+      "bin": {
+        "puml": "index.js"
+      },
+      "engines": {
+        "node": ">= 6.x"
+      }
+    },
+    "node_modules/node-plantuml/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -4757,6 +4907,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -4858,6 +5017,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4942,6 +5110,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/plantuml-encoder": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/plantuml-encoder/-/plantuml-encoder-1.4.0.tgz",
+      "integrity": "sha512-sxMwpDw/ySY1WB2CE3+IdMuEcWibJ72DDOsXLkSmEaSzwEUaYBT6DWgOfBiHGCux4q433X6+OEFWjlVqp7gL6g==",
+      "dev": true
     },
     "node_modules/postcss": {
       "version": "8.4.49",
@@ -5129,6 +5303,21 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5242,6 +5431,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "node_modules/react-nice-avatar": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/react-nice-avatar/-/react-nice-avatar-1.5.0.tgz",
+      "integrity": "sha512-sGusqbgWIA4Il6Y0zHEfs4XF+a06etNljhwFYiHIGATDmVVf53Nez7U7GY5EwEz5/xGuUhs6uel5AC5NN/2UPg==",
+      "dependencies": {
+        "@babel/runtime": "^7.14.3",
+        "chroma-js": "^2.1.2",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -5398,8 +5600,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -5411,9 +5612,9 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.9",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.9.tgz",
-      "integrity": "sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dependencies": {
         "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
@@ -5421,6 +5622,9 @@
       },
       "bin": {
         "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6039,21 +6243,21 @@
       }
     },
     "node_modules/tldts": {
-      "version": "6.1.68",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.68.tgz",
-      "integrity": "sha512-JKF17jROiYkjJPT73hUTEiTp2OBCf+kAlB+1novk8i6Q6dWjHsgEjw9VLiipV4KTJavazXhY1QUXyQFSem2T7w==",
+      "version": "6.1.69",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.69.tgz",
+      "integrity": "sha512-Oh/CqRQ1NXNY7cy9NkTPUauOWiTro0jEYZTioGbOmcQh6EC45oribyIMJp0OJO3677r13tO6SKdWoGZUx2BDFw==",
       "dev": true,
       "dependencies": {
-        "tldts-core": "^6.1.68"
+        "tldts-core": "^6.1.69"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.68",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.68.tgz",
-      "integrity": "sha512-85TdlS/DLW/gVdf2oyyzqp3ocS30WxjaL4la85EArl9cHUR/nizifKAJPziWewSZjDZS71U517/i6ciUeqtB5Q==",
+      "version": "6.1.69",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.69.tgz",
+      "integrity": "sha512-nygxy9n2PBUFQUtAXAc122gGo+04/j5qr5TGQFZTHafTKYvmARVXt2cA5rgero2/dnXUfkdPtiJoKmrd3T+wdA==",
       "dev": true
     },
     "node_modules/to-regex-range": {
@@ -6085,6 +6289,68 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tplant": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tplant/-/tplant-3.1.3.tgz",
+      "integrity": "sha512-2LuWRFmpoipfme0c1B8GWZSHm9KEJKIyqC+u7qZUdQSwk0UyycTDD+fvtTJ9PosRrGLoSehnsfhJzX2gOckLig==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^6.1.0",
+        "glob": "^7.1.6",
+        "node-plantuml": "0.9.0",
+        "plantuml-encoder": "^1.4.0",
+        "typescript": "5.2.2"
+      },
+      "bin": {
+        "tplant": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/tplant/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tplant/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tplant/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/tr46": {
@@ -7057,6 +7323,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/ws": {
       "version": "8.18.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-scroll-area": "^1.2.2",
         "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-tooltip": "^1.1.6",
         "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^4.3.3",
         "class-variance-authority": "^0.7.1",
@@ -875,6 +876,40 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.8.tgz",
+      "integrity": "sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.12.tgz",
+      "integrity": "sha512-NP83c0HjokcGVEMeoStg317VD9W7eDlGK7457dMBANbKA6GJZdc7rjujdgqzTaz93jkGgc5P/jeWbaCHnMNc+w==",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.8"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1045,6 +1080,28 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
       "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA=="
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.1.tgz",
+      "integrity": "sha512-NaVpZfmv8SKeZbn4ijN2V3jlHA9ngBG16VnIIm22nUR0Yk8KUALyBxT3KYEUnNuch9sTE8UTsS3whzBgKOL30w==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.1",
@@ -1226,6 +1283,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.1.tgz",
+      "integrity": "sha512-3kn5Me69L+jv82EKRuQCXdYyf1DqHwD2U/sxoNgBGCB7K9TRc3bQamQ+5EPM9EvyPdli0W41sROd+ZU1dTCztw==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.3.tgz",
@@ -1341,6 +1429,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.6.tgz",
+      "integrity": "sha512-TLB5D8QLExS1uDn7+wH/bjEmRurNMTzNrtq7IjaS4kjion9NtzsTGkvR5+i7yc9q01Pi2KMM2cN3f8UG4IvvXA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.3",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.1",
+        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-slot": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -1402,6 +1523,67 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+      "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.1.tgz",
+      "integrity": "sha512-vVfA2IZ9q/J+gEamvj761Oq1FpWgCDaNOOIfbPVp2MVPLEomUr5+Vf7kJGwQ24YxZSlQVar7Bes8kyTo5Dshpg==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.28.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-label": "^2.1.1",
+    "@radix-ui/react-scroll-area": "^1.2.2",
     "@radix-ui/react-slot": "^1.1.0",
     "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.3.3",
@@ -28,6 +29,7 @@
     "react": "^18.3.1",
     "react-card-flip": "^1.2.3",
     "react-dom": "^18.3.1",
+    "react-nice-avatar": "^1.5.0",
     "react-router-dom": "^7.0.1",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-scroll-area": "^1.2.2",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tooltip": "^1.1.6",
     "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.3.3",
     "class-variance-authority": "^0.7.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { TitlePage } from "./presentation/pages/Title";
 import { MatchPage } from "./presentation/pages/Match";
+import { MatchStartPage } from "./presentation/pages/Match-start";
 
 export function App() {
   return (
@@ -9,6 +10,7 @@ export function App() {
         <Routes>
           <Route path="/" element={<TitlePage />} />
           <Route path="/match" element={<MatchPage />} />
+          <Route path="/match-start" element={<MatchStartPage />} />
         </Routes>
       </BrowserRouter>
     </>

--- a/src/index.css
+++ b/src/index.css
@@ -88,7 +88,12 @@ body,
   }
 }
 
-.Polka {
+.GreenDot {
   background-image: radial-gradient(#01562d 1px, #004b27 1px);
+  background-size: 5px 5px;
+}
+
+.WhiteDot {
+  background-image: radial-gradient(#d3d1d188 1px, #f6f6f6 1px);
   background-size: 5px 5px;
 }

--- a/src/presentation/components/match-start/player-card.tsx
+++ b/src/presentation/components/match-start/player-card.tsx
@@ -1,0 +1,34 @@
+import Avatar, { genConfig } from "react-nice-avatar";
+
+import { Button } from "@/presentation/shadcnUI/components/ui/button";
+
+// TODO: ドメインに合わせて、プレイヤーの型を参照する
+interface PlayerCardProps {
+  player: Player;
+  onAction: (player: Player) => void;
+  actionLabel: string;
+  variant?: "danger";
+}
+
+export const PlayerCard = ({
+  player,
+  onAction,
+  actionLabel,
+  variant,
+}: PlayerCardProps) => {
+  const config = genConfig(player.name);
+  return (
+    <div className="flex flex-row sm:flex-col justify-between items-center bg-white p-2 rounded-md w-full sm:w-[220px] gap-y-1 gap-x-1">
+      <Avatar className="size-10 md:size-16" {...config} />
+      <p>{player.name}</p>
+      <Button
+        size="sm"
+        variant={variant}
+        className="uppercase"
+        onClick={() => onAction(player)}
+      >
+        {actionLabel}
+      </Button>
+    </div>
+  );
+};

--- a/src/presentation/components/match/bet-modal.tsx
+++ b/src/presentation/components/match/bet-modal.tsx
@@ -22,7 +22,7 @@ export const BetModal = () => {
   return (
     <>
       <Dialog open={isOpen} onOpenChange={onClose}>
-        <DialogContent className="space-y-2 Polka border-2 border-yellow-500 shadow-sm shadow-yellow-500">
+        <DialogContent className="space-y-2 GreenDot border-2 border-yellow-500 shadow-sm shadow-yellow-500">
           <DialogHeader>
             <DialogTitle className="">Place Your Bet!</DialogTitle>
             <DialogDescription className="text-black">

--- a/src/presentation/pages/Match-start.tsx
+++ b/src/presentation/pages/Match-start.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
+import { PlayerCard } from "../components/match-start/player-card";
+
+import { Button } from "../shadcnUI/components/ui/button";
+import { ScrollArea } from "../shadcnUI/components/ui/scroll-area";
+
+import { cn } from "../shadcnUI/lib/utils";
+
+export const MatchStartPage = () => {
+  const navigate = useNavigate();
+
+  // TODO: ドメインに合わせて、プレイヤーの型を参照する
+  const [selectedPlayers, setSelectedPlayers] = useState([
+    { id: 1, name: "Chris Johnson", image: "https://via.placeholder.com/80" },
+    { id: 2, name: "Laura Smith", image: "https://via.placeholder.com/80" },
+  ]);
+
+  // TODO: ドメインに合わせて、プレイヤーの型を参照する
+  const [registeredPlayers, setRegisteredPlayers] = useState([
+    { id: 3, name: "若松 隼也", image: "https://via.placeholder.com/80" },
+    { id: 4, name: "さき", image: "https://via.placeholder.com/80" },
+    { id: 5, name: "はなこ", image: "https://via.placeholder.com/80" },
+    { id: 6, name: "桜", image: "https://via.placeholder.com/80" },
+    { id: 7, name: "Charlie Brown", image: "https://via.placeholder.com/80" },
+    { id: 8, name: "David Johnson", image: "https://via.placeholder.com/80" },
+    { id: 9, name: "Eve Smith", image: "https://via.placeholder.com/80" },
+    { id: 10, name: "Frank Brown", image: "https://via.placeholder.com/80" },
+    { id: 11, name: "Grace Johnson", image: "https://via.placeholder.com/80" },
+    { id: 12, name: "Harry Smith", image: "https://via.placeholder.com/80" },
+    { id: 13, name: "Ivy Brown", image: "https://via.placeholder.com/80" },
+    { id: 14, name: "Jack Johnson", image: "https://via.placeholder.com/80" },
+    { id: 15, name: "Kelly Smith", image: "https://via.placeholder.com/80" },
+    { id: 16, name: "Larry Brown", image: "https://via.placeholder.com/80" },
+    { id: 17, name: "Mary Johnson", image: "https://via.placeholder.com/80" },
+    { id: 18, name: "Nancy Smith", image: "https://via.placeholder.com/80" },
+  ]);
+
+  // TODO: ドメインに合わせて、プレイヤーの型を参照する
+  const handleAddSelectedPlayer = (player) => {
+    setSelectedPlayers([...selectedPlayers, player]);
+    setRegisteredPlayers(registeredPlayers.filter((p) => p.id !== player.id));
+  };
+
+  // TODO: ドメインに合わせて、プレイヤーの型を参照する
+  const handleRemoveSelectedPlayer = (player) => {
+    setRegisteredPlayers([...registeredPlayers, player]);
+    setSelectedPlayers(selectedPlayers.filter((p) => p.id !== player.id));
+  };
+
+  // TODO: マッチを開始して、選択されたプレイヤーをbackendに送信し、マッチIDを取得する関数を実装
+  // TODO: プレイヤーが設定されていなければ、ボタンを無効にする
+  const handleStartMatch = () => {
+    // TODO: /match/:idに変更する
+    navigate("/match");
+  };
+
+  useEffect(() => {
+    // TODO: プレイヤーの一覧を取得する関数を実装
+  }, []);
+
+  return (
+    <>
+      <div className="min-h-screen">
+        <div className="w-full flex justify-between border-b-2 mx-auto py-2">
+          <Link className="hover:text-transparent" to="/">
+            <div className="flex items-center">
+              <img src="/Drump.png" alt="Drump Logo" className="size-8 " />
+              <h1 className="text-2xl font-['Dela_Gothic_One'] [-webkit-text-stroke:1px_#fff462] pb-1">
+                Black Jack
+              </h1>
+            </div>
+          </Link>
+          <div>
+            <Button
+              size="sm"
+              variant="successOutline"
+              className="uppercase rounded-full"
+              asChild
+            >
+              <Link to="/users">Add to Player List</Link>
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-col justify-center items-center min-h-full WhiteDot">
+          <div className="w-[70%] mt-2 mb-3 pt-2 p-4 bg-gradient-to-br from-green-400 via-green-500 to-green-400 rounded-xl border-2 border-neutral-300">
+            <h2 className="text-xl font-bold text-black">
+              Selected Players List
+            </h2>
+            <ScrollArea className="h-[200px]">
+              <div className="flex flex-wrap gap-4 mt-4">
+                {selectedPlayers.length === 0 ? (
+                  <p className="text-center text-gray-500">
+                    No players selected. Please add players to start the game.
+                  </p>
+                ) : (
+                  selectedPlayers.map((player) => (
+                    <PlayerCard
+                      key={player.id}
+                      player={player}
+                      onAction={handleRemoveSelectedPlayer}
+                      actionLabel="Remove"
+                      variant="danger"
+                    />
+                  ))
+                )}
+              </div>
+            </ScrollArea>
+          </div>
+          <div className="w-[70%] mt-2 mb-3 pt-2 p-4 bg-gradient-to-br from-neutral-100 via-neutral-300 to-neutral-100 rounded-xl border-2 border-neutral-300">
+            <h2 className="text-xl font-bold text-black">
+              Registered Players List
+            </h2>
+            <ScrollArea className="h-[200px]">
+              <div className="flex flex-wrap gap-4 mt-4">
+                {registeredPlayers.length === 0 ? (
+                  <p className="text-center text-gray-500">
+                    No registered players available.
+                  </p>
+                ) : (
+                  registeredPlayers.map((player) => (
+                    <PlayerCard
+                      key={player.id}
+                      player={player}
+                      onAction={handleAddSelectedPlayer}
+                      actionLabel="Add"
+                    />
+                  ))
+                )}
+              </div>
+            </ScrollArea>
+          </div>
+          <div className="mt-6">
+            <div
+              className={cn(
+                "border-2 border-yellow-500 rounded-md",
+                selectedPlayers.length !== 0 && "animate-bounce"
+              )}
+            >
+              <Button
+                onClick={handleStartMatch}
+                size="lg"
+                variant={selectedPlayers.length === 0 ? "locked" : "success"}
+                disabled={selectedPlayers.length === 0}
+                className="uppercase"
+              >
+                Game Start
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/presentation/pages/Match-start.tsx
+++ b/src/presentation/pages/Match-start.tsx
@@ -20,28 +20,28 @@ export const MatchStartPage = () => {
 
   // TODO: ドメインに合わせて、プレイヤーの型を参照する
   const [selectedPlayers, setSelectedPlayers] = useState([
-    { id: 1, name: "Chris Johnson", image: "https://via.placeholder.com/80" },
-    { id: 2, name: "Laura Smith", image: "https://via.placeholder.com/80" },
+    { id: 1, name: "Chris Johnson" },
+    { id: 2, name: "Laura Smith" },
   ]);
 
   // TODO: ドメインに合わせて、プレイヤーの型を参照する
   const [registeredPlayers, setRegisteredPlayers] = useState([
-    { id: 3, name: "若松 隼也", image: "https://via.placeholder.com/80" },
-    { id: 4, name: "さき", image: "https://via.placeholder.com/80" },
-    { id: 5, name: "はなこ", image: "https://via.placeholder.com/80" },
-    { id: 6, name: "桜", image: "https://via.placeholder.com/80" },
-    { id: 7, name: "Charlie Brown", image: "https://via.placeholder.com/80" },
-    { id: 8, name: "David Johnson", image: "https://via.placeholder.com/80" },
-    { id: 9, name: "Eve Smith", image: "https://via.placeholder.com/80" },
-    { id: 10, name: "Frank Brown", image: "https://via.placeholder.com/80" },
-    { id: 11, name: "Grace Johnson", image: "https://via.placeholder.com/80" },
-    { id: 12, name: "Harry Smith", image: "https://via.placeholder.com/80" },
-    { id: 13, name: "Ivy Brown", image: "https://via.placeholder.com/80" },
-    { id: 14, name: "Jack Johnson", image: "https://via.placeholder.com/80" },
-    { id: 15, name: "Kelly Smith", image: "https://via.placeholder.com/80" },
-    { id: 16, name: "Larry Brown", image: "https://via.placeholder.com/80" },
-    { id: 17, name: "Mary Johnson", image: "https://via.placeholder.com/80" },
-    { id: 18, name: "Nancy Smith", image: "https://via.placeholder.com/80" },
+    { id: 3, name: "若松 隼也" },
+    { id: 4, name: "さき" },
+    { id: 5, name: "はなこ" },
+    { id: 6, name: "桜" },
+    { id: 7, name: "Charlie Brown" },
+    { id: 8, name: "David Johnson" },
+    { id: 9, name: "Eve Smith" },
+    { id: 10, name: "Frank Brown" },
+    { id: 11, name: "Grace Johnson" },
+    { id: 12, name: "Harry Smith" },
+    { id: 13, name: "Ivy Brown" },
+    { id: 14, name: "Jack Johnson" },
+    { id: 15, name: "Kelly Smith" },
+    { id: 16, name: "Larry Brown" },
+    { id: 17, name: "Mary Johnson" },
+    { id: 18, name: "Nancy Smith" },
   ]);
 
   // TODO: ドメインに合わせて、プレイヤーの型を参照する

--- a/src/presentation/pages/Match-start.tsx
+++ b/src/presentation/pages/Match-start.tsx
@@ -1,10 +1,17 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { CirclePlus } from "lucide-react";
 
 import { PlayerCard } from "../components/match-start/player-card";
 
 import { Button } from "../shadcnUI/components/ui/button";
 import { ScrollArea } from "../shadcnUI/components/ui/scroll-area";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../shadcnUI/components/ui/tooltip";
 
 import { cn } from "../shadcnUI/lib/utils";
 
@@ -73,14 +80,29 @@ export const MatchStartPage = () => {
             </div>
           </Link>
           <div>
-            <Button
-              size="sm"
-              variant="successOutline"
-              className="uppercase rounded-full"
-              asChild
-            >
-              <Link to="/users">Add to Player List</Link>
-            </Button>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="sm"
+                    variant="successOutline"
+                    className="uppercase rounded-full"
+                    asChild
+                  >
+                    <Link to="/users">
+                      <span className="hidden md:block">
+                        Add to Player List
+                      </span>
+
+                      <CirclePlus className="block md:hidden" size={24} />
+                    </Link>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <span className="text-base">Add to Player List</span>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         </div>
 

--- a/src/presentation/pages/Title.tsx
+++ b/src/presentation/pages/Title.tsx
@@ -14,7 +14,7 @@ export const TitlePage = () => {
         <div className="space-y-4 md:space-y-8">
           <TitleButton
             to="match-start"
-            text="スタート"
+            text="Play"
             icon={ArrowRight}
             buttonSize="md:w-48"
             direction="flex-row-reverse"

--- a/src/presentation/shadcnUI/components/ui/button.tsx
+++ b/src/presentation/shadcnUI/components/ui/button.tsx
@@ -32,7 +32,7 @@ const buttonVariants = cva(
         superOutline:
           "bg-gradient-to-b from-neutral-50 via-neutral-200 to-neutral-300 text-indigo-600 hover:from-indigo-400 hover:via-indigo-600 hover:to-indigo-800 border-neutral-400 hover:border-indigo-900 hover:text-white border-b-4 border-x-2 active:border-b-0",
         locked:
-          "bg-neutral-200 text-stone-300 text-primary-foreground hover:bg-neutral-300 border-neutral-400 border-b-4",
+          "bg-neutral-200 text-black hover:bg-neutral-300 border-neutral-400 border-b-4",
       },
       size: {
         default: "h-11 px-4 py-2",

--- a/src/presentation/shadcnUI/components/ui/scroll-area.tsx
+++ b/src/presentation/shadcnUI/components/ui/scroll-area.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/presentation/shadcnUI/lib/utils"
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+export { ScrollArea, ScrollBar }

--- a/src/presentation/shadcnUI/components/ui/tooltip.tsx
+++ b/src/presentation/shadcnUI/components/ui/tooltip.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/presentation/shadcnUI/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }


### PR DESCRIPTION
# やったこと
- match-start画面
  - 登録されているプレイヤーの中から、今回ブラックジャックを行うプレイヤーを選択する画面
  - アイコン : プレイヤー側で設定できるようにできたらいいなとは思いますが、スケジュール的に以下ライブラリで代用シています
  - https://www.npmjs.com/package/react-nice-avatar
- title画面
  - match-start画面側で、ボタンを「GAME START」にしたため、Playの文言に変更しています

※型等に関してはドメイン側作成後に変更が入ると思うので、TODOとして残しています

# デモ
match-start画面
![スクリーンショット 2024-12-22 224419](https://github.com/user-attachments/assets/af7bd0f3-fc1c-4080-a24f-202dc4c0c94a)

画面幅が小さい場合のmatch-start画面 
![スクリーンショット 2024-12-22 230914](https://github.com/user-attachments/assets/f4cc1fdf-3857-4d58-9741-3427a2ffc099)


タイトル画面
![スクリーンショット 2024-12-22 224454](https://github.com/user-attachments/assets/fe189aae-940d-465e-9123-2258bf8fd1a1)

# 参考

もっとプロダクトをこうしたい！等あれば、コメントください
