### PR TITLE
トランプの位置修正

### DIFF
--- a/src/presentation/components/match/Card.tsx
+++ b/src/presentation/components/match/Card.tsx
@@ -5,11 +5,16 @@ import { MatchGetPlayerHandApiResponseCard } from "../../types/matchGetPlayerHan
 
 export const Card = ({
   isOpen,
+  initial,
   animate,
   suit,
   rank,
 }: {
   isOpen: boolean;
+  initial: {
+    x: string;
+    y: string;
+  };
   animate: {
     x: string;
     y: string;
@@ -21,7 +26,7 @@ export const Card = ({
 
   return (
     <motion.div
-      initial={{ x: "100vw", y: "25vh" }}
+      initial={initial}
       animate={animate}
       transition={{
         type: "linear",
@@ -33,14 +38,17 @@ export const Card = ({
           setIsFlipped(true);
         }
       }}
-      className="flex space-x-4"
     >
       <ReactCardFlip isFlipped={isFlipped} flipDirection="horizontal">
-        <div className="mt-5 mr-2 h-40 w-24">
-          <img src="/trump/back.png" alt="card-back" />
+        <div className="h-40 w-24">
+          <img className="rounded-lg" src="/trump/back.png" alt="card-back" />
         </div>
-        <div className="mt-5 mr-2 h-40 w-24">
-          <img src={`/trump/${suit}${rank}.png`} alt="" />
+        <div className="h-40 w-24">
+          <img
+            className="rounded-lg"
+            src={`/trump/${suit}${rank}.png`}
+            alt="trump-card"
+          />
         </div>
       </ReactCardFlip>
     </motion.div>

--- a/src/presentation/pages/Match-start.tsx
+++ b/src/presentation/pages/Match-start.tsx
@@ -177,7 +177,7 @@ export const MatchStartPage = () => {
           </div>
         </div>
 
-        <div className="flex flex-col justify-center items-center min-h-full WhiteDot">
+        <div className="flex flex-col justify-center items-center min-h-screen WhiteDot">
           <div className="w-[70%] mt-2 mb-3 pt-2 p-4 bg-gradient-to-br from-green-400 via-green-500 to-green-400 rounded-xl border-2 border-neutral-300">
             <h2 className="text-xl font-bold text-black">
               Selected Players List

--- a/src/presentation/pages/Match.tsx
+++ b/src/presentation/pages/Match.tsx
@@ -284,7 +284,7 @@ export const MatchPage = () => {
                     key={card.suit + card.rank}
                     isOpen={true}
                     initial={{ x: "50vw", y: "-25vh" }}
-                    animate={{ x: "0", y: "0" }}
+                    animate={{ x: "0vw", y: "0vh" }}
                     suit={card.suit}
                     rank={card.rank}
                   />

--- a/src/presentation/pages/Match.tsx
+++ b/src/presentation/pages/Match.tsx
@@ -390,7 +390,7 @@ export const MatchPage = () => {
         </div>
       </div>
 
-      {/* <BetModal /> */}
+      <BetModal />
     </div>
   );
 };

--- a/src/presentation/pages/Match.tsx
+++ b/src/presentation/pages/Match.tsx
@@ -36,10 +36,10 @@ export const MatchPage = () => {
   // TODO: ドメイン層からプレイヤー情報を取得する
   // ハンドではなく、スートとランクにするかも、ほかプレイヤーの情報は変更の可能性あり
   const [players, setPlayers] = useState([
-    { id: 2, name: "Player 2", hand: 18, isCurrent: true },
     { id: 1, name: "Player 1", hand: 10, isCurrent: false },
     { id: 5, name: "Player 5", hand: 14, isCurrent: false },
     { id: 3, name: "Player 3", hand: 12, isCurrent: false },
+    { id: 2, name: "Player 2", hand: 18, isCurrent: true },
     { id: 4, name: "Player 4", hand: 8, isCurrent: false },
     { id: 6, name: "Player 6", hand: 16, isCurrent: false },
     { id: 7, name: "Player 7", hand: 20, isCurrent: false },
@@ -231,21 +231,22 @@ export const MatchPage = () => {
 
       <div
         id="gameTable"
-        className="p-3 flex flex-col justify-between h-[80vh]"
+        className="pt-3 flex flex-col justify-between h-[75vh]"
       >
         <div id="dealer" className="bg-neutral-50/5 rounded-md relative">
           <div className="absolute top-1/2 -right-9 px-3 py-1.5 border-2 font-bold text-white bg-black rounded-xl z-10">
             4
             <div className="absolute top-1/2 -left-2 w-0 h-0 border-y-8 border-y-transparent border-r-8 transform -translate-y-1/2" />
           </div>
-          <div className="flex">
+          <div className="flex space-x-2">
             {dealerCards &&
               dealerCards.map((card) => {
                 return (
                   <Card
                     key={card.suit + card.rank}
                     isOpen={true}
-                    animate={{ x: "40vw", y: "0vh" }}
+                    initial={{ x: "50vw", y: "25vh" }}
+                    animate={{ x: "0vw", y: "0vh" }}
                     suit={card.suit}
                     rank={card.rank}
                   />
@@ -255,7 +256,8 @@ export const MatchPage = () => {
               <Card
                 key="reverse"
                 isOpen={false}
-                animate={{ x: "40vw", y: "0vh" }}
+                initial={{ x: "50vw", y: "25vh" }}
+                animate={{ x: "0vw", y: "0vh" }}
                 suit={"reverse"}
                 rank={"reverse"}
               />
@@ -267,24 +269,22 @@ export const MatchPage = () => {
           id="player"
           className="bg-neutral-50/5 text-center rounded-md relative"
         >
-          <h2 className="bg-gradient-to-b from-slate-300/40 via-slate-100/10 to-slate-50/5 text-white text-xl font-bold rounded-t-md">
+          <h2 className="bg-gradient-to-b from-slate-300/40 via-slate-100/10 to-slate-50/5 text-white text-lg font-bold rounded-t-md">
             Bet: 35
           </h2>
           <div className="absolute top-1/2 -right-9 px-2 py-1.5 border-2 font-bold text-white bg-black rounded-xl z-10">
             10/20
             <div className="absolute top-1/2 -left-2 w-0 h-0 border-y-8 border-y-transparent border-r-8 transform -translate-y-1/2" />
           </div>
-          <div className="flex">
+          <div className="flex space-x-2">
             {playerHand &&
               playerHand.cards.map((card) => {
                 return (
                   <Card
                     key={card.suit + card.rank}
                     isOpen={true}
-                    animate={{
-                      x: "40vw",
-                      y: "25vh",
-                    }}
+                    initial={{ x: "50vw", y: "-25vh" }}
+                    animate={{ x: "0", y: "0" }}
                     suit={card.suit}
                     rank={card.rank}
                   />
@@ -294,6 +294,24 @@ export const MatchPage = () => {
         </div>
       </div>
 
+      <div id="shoe" className="hidden md:block absolute top-28 right-4">
+        <div className="relative h-40 w-24">
+          <div className="absolute inset-0 transform translate-x-0 translate-y-0">
+            <img className="rounded-lg" src="/trump/back.png" alt="card-back" />
+          </div>
+          <div className="absolute inset-0 transform translate-x-1 translate-y-1 z-10">
+            <img className="rounded-lg" src="/trump/back.png" alt="card-back" />
+          </div>
+          <div className="absolute inset-0 transform translate-x-2 translate-y-2 z-20">
+            <img className="rounded-lg" src="/trump/back.png" alt="card-back" />
+          </div>
+          <div className="absolute inset-0 transform translate-x-3 translate-y-3 z-30">
+            <img className="rounded-lg" src="/trump/back.png" alt="card-back" />
+          </div>
+        </div>
+      </div>
+
+      {/* TODO: 位置を調整する */}
       <div id="otherPlayerInfo" className="absolute w-full">
         {players.map((player, index) => {
           if (!player.isCurrent) {
@@ -362,17 +380,17 @@ export const MatchPage = () => {
 
       <div
         id="playerInfo"
-        className="bg-white rounded-lg flex justify-around py-2 w-[30%]"
+        className="bg-white rounded-lg flex justify-around py-2 mb-1 w-[30%]"
       >
-        <Avatar className="size-8" {...avatarConfig} />
-        <div className="flex justify-between items-center px-5 gap-x-4 ">
+        <Avatar className="hidden md:block size-8" {...avatarConfig} />
+        <div className="flex justify-between items-center gap-x-4 ">
           {/* TODO: 現在のプレイヤーの情報を取得する */}
           <p className="text-center text-black font-semibold">Player 2</p>
           <p className="text-center text-black font-semibold">Credit: 100</p>
         </div>
       </div>
 
-      <BetModal />
+      {/* <BetModal /> */}
     </div>
   );
 };


### PR DESCRIPTION
# やったこと
- Match画面
  - トランプの位置修正
    - framer-motionを使用したトランプの位置調整において、座標軸の基準が要素の初期位置となっています。そのため、xやyにvwやvhを指定しても、長さ自体は画面幅や高さを基準に計算されますが、最上位レイヤーにitems-centerが設定されている影響で、トランプを内包する要素が画面中央に配置されてしまいます。
    - 結果として、画面中央が座標軸の初期位置となり、xに100vwを指定すると、画面外にはみ出してしまう状態でした。
    - この問題を解決するため、ディーラーとプレイヤーそれぞれのトランプのドロースタート位置を明示的に指定しました。
    - また、vwやvhを使用して相対位置を指定していますが、相対位置である点が気になっています。ただし、pxで指定するのも適切ではないと判断し、現状の実装にしています。
  - デッキUIの追加
    - トランプのドロースタート位置にデッキUIを追加しました。
  - CSSの修正
- Match-start画面
  - 背景画像が画面の拡大縮小に依存しないよう修正しました。

# デモ

https://github.com/user-attachments/assets/5ce1f51d-5397-4f00-bc55-3c026154f4bc

※モーダルを出ないようにしてからデモしています。

![スクリーンショット 2024-12-28 203955](https://github.com/user-attachments/assets/86b66ba0-0c87-44bd-a115-b72fdb140660)

![スクリーンショット 2024-12-28 204737](https://github.com/user-attachments/assets/b9705b6e-1a10-48f8-8fc5-c8c5dbaa398c)


# 参考
https://motion.dev/docs/react-animation
