### PR TITLE
ユーザー作成画面の作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-dom": "^18.3.1",
         "react-nice-avatar": "^1.5.0",
         "react-router-dom": "^7.0.1",
+        "react-use": "^17.6.0",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
         "vite-express": "^0.20.0",
@@ -691,7 +692,8 @@
     },
     "node_modules/@radix-ui/react-dialog": {
       "version": "1.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.4.tgz",
+      "integrity": "sha512-Ur7EV1IwQGCyaAuyDRiOLA5JIUZxELJljF+MbM/2NC0BYwfuRrbpS30BiQBJrVruscgUkieKkqXYDOoByaxIoA==",
       "dependencies": {
         "@radix-ui/primitive": "1.1.1",
         "@radix-ui/react-compose-refs": "1.1.1",
@@ -1421,6 +1423,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-cookie": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
+      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
@@ -1828,6 +1835,11 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -2396,6 +2408,14 @@
       "version": "1.0.6",
       "license": "MIT"
     },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "license": "MIT",
@@ -2406,6 +2426,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-in-js-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.3"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/css.escape": {
@@ -2574,6 +2614,14 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
       }
     },
     "node_modules/es-define-property": {
@@ -2921,7 +2969,6 @@
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -2957,6 +3004,16 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "node_modules/fastest-stable-stringify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "node_modules/fastq": {
       "version": "1.18.0",
@@ -3363,6 +3420,11 @@
         "node": ">= 14"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "license": "MIT",
@@ -3424,6 +3486,14 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
+    },
+    "node_modules/inline-style-prefixer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
+      "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
+      "dependencies": {
+        "css-in-js-utils": "^3.1.0"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -3514,6 +3584,11 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3714,6 +3789,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "license": "MIT",
@@ -3839,6 +3919,25 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nano-css": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.6.2.tgz",
+      "integrity": "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "css-tree": "^1.1.2",
+        "csstype": "^3.1.2",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^7.0.1",
+        "rtl-css-js": "^1.16.1",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.3.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/nanoid": {
@@ -4599,6 +4698,40 @@
         }
       }
     },
+    "node_modules/react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==",
+      "peerDependencies": {
+        "react": "*",
+        "tslib": "*"
+      }
+    },
+    "node_modules/react-use": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.6.0.tgz",
+      "integrity": "sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==",
+      "dependencies": {
+        "@types/js-cookie": "^2.2.6",
+        "@xobotyi/scrollbar-width": "^1.9.5",
+        "copy-to-clipboard": "^3.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.6.2",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.1.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^3.0.1",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "license": "MIT",
@@ -4639,6 +4772,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -4723,6 +4861,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rtl-css-js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.1.tgz",
+      "integrity": "sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "funding": [
@@ -4782,6 +4928,17 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semver": {
@@ -4847,6 +5004,14 @@
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "license": "MIT"
+    },
+    "node_modules/set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==",
+      "engines": {
+        "node": ">=6.9"
+      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -4948,6 +5113,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
@@ -4955,10 +5128,50 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -5069,6 +5282,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.4.tgz",
+      "integrity": "sha512-osIBl6BGUmSfDkyH2mB7EFvCJntXDrLhKjHTRj/rK6xLH0yuPrHULDRQzKokSOD4VoorhtKpfcfW1GAntu8now=="
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
@@ -5183,6 +5401,14 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/throttle-debounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "dev": true,
@@ -5242,6 +5468,11 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -5339,6 +5570,11 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^18.3.1",
     "react-nice-avatar": "^1.5.0",
     "react-router-dom": "^7.0.1",
+    "react-use": "^17.6.0",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vite-express": "^0.20.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { TitlePage } from "./presentation/pages/Title";
-import { MatchPage } from "./presentation/pages/Match";
+import { UsersPage } from "./presentation/pages/Users";
 import { MatchStartPage } from "./presentation/pages/Match-start";
+import { MatchPage } from "./presentation/pages/Match";
 
 export function App() {
   return (
@@ -9,8 +10,9 @@ export function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<TitlePage />} />
-          <Route path="/match/:matchId" element={<MatchPage />} />
+          <Route path="/users" element={<UsersPage />} />
           <Route path="/match-start" element={<MatchStartPage />} />
+          <Route path="/match/:matchId" element={<MatchPage />} />
         </Routes>
       </BrowserRouter>
     </>

--- a/src/presentation/components/share/header.tsx
+++ b/src/presentation/components/share/header.tsx
@@ -1,0 +1,21 @@
+import { Link } from "react-router-dom";
+import { Logo } from "./logo";
+import { Navigation } from "./navigation";
+
+export const Header = () => {
+  return (
+    <>
+      <div className="w-full flex items-center justify-between border-b-2 mx-auto py-0 md:py-1 fixed top-0 bg-green-400 lg:bg-white z-10">
+        <Link className="hover:text-transparent" to="/">
+          <div className="hidden lg:flex items-center">
+            <Logo size={8} />
+            <p className="text-2xl font-['Dela_Gothic_One'] [-webkit-text-stroke:1px_#fff462] ml-2.5">
+              Black Jack
+            </p>
+          </div>
+        </Link>
+        <Navigation />
+      </div>
+    </>
+  );
+};

--- a/src/presentation/components/share/navigation.tsx
+++ b/src/presentation/components/share/navigation.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useMedia } from "react-use";
+import {
+  Menu,
+  ChartColumn,
+  House,
+  Users,
+  BookOpenText,
+  ArrowRight,
+} from "lucide-react";
+
+import { Logo } from "./logo";
+
+import { Button } from "@/presentation/shadcnUI/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetTrigger,
+} from "@/presentation/shadcnUI/components/ui/sheet";
+
+import { cn } from "@/presentation/shadcnUI/lib/utils";
+
+const routes = [
+  {
+    to: "/",
+    label: "Home",
+    Icon: House,
+  },
+  {
+    to: "/users",
+    label: "Players",
+    Icon: Users,
+  },
+  {
+    to: "/scores",
+    label: "Scores",
+    Icon: ChartColumn,
+  },
+  {
+    to: "/rules",
+    label: "Rules",
+    Icon: BookOpenText,
+  },
+];
+
+export const Navigation = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const navigation = useNavigate();
+  const pathname = useLocation().pathname;
+  const isMobile = useMedia("(max-width: 1024px)", false);
+
+  const onClick = (to: string) => {
+    navigation(to);
+    setIsOpen(false);
+  };
+
+  if (isMobile) {
+    return (
+      <>
+        <Sheet open={isOpen} onOpenChange={setIsOpen}>
+          <SheetTrigger className="bg-gradient-to-l from-green-400 via-green-300 to-green-400">
+            <Button
+              variant="transparent"
+              size="md"
+              className="font-normal border-none focus-visible:ring-offset-0 focus-visible:ring-transparent outline-none text-black transition"
+            >
+              <Menu size="size-4" />
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="right" className="px-2">
+            <div className="flex items-center">
+              <Logo size={16} />
+              <p className="text-4xl font-['Dela_Gothic_One'] [-webkit-text-stroke:1px_#fff462] ml-2.5">
+                Black Jack
+              </p>
+            </div>
+            <nav className="flex flex-col gap-y-2 pt-6">
+              {pathname !== "/match-start" ? (
+                <div className="border-b-2 pb-2 border-slate-300">
+                  <Button
+                    variant="success"
+                    size="lg"
+                    onClick={() => onClick("/match-start")}
+                    className="w-full"
+                  >
+                    <span className="text-lg">Play</span>
+                    <ArrowRight className="size-8" />
+                  </Button>
+                </div>
+              ) : null}
+              {routes.map((route) => (
+                <Button
+                  key={route.to}
+                  variant={route.to === pathname ? "outline" : "ghost"}
+                  onClick={() => onClick(route.to)}
+                  className={cn(
+                    "w-full flex items-center justify-start gap-x-6 px-0",
+                    route.to === pathname ? "text-green-500" : "text-black"
+                  )}
+                >
+                  <route.Icon className="size-8 ml-2" />
+                  <span>{route.label}</span>
+                </Button>
+              ))}
+            </nav>
+          </SheetContent>
+        </Sheet>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <nav className="hidden lg:flex items-center gap-x-2 overflow-x-auto pl-2">
+        {routes.map((route) => (
+          <Button
+            key={route.to}
+            size="sm"
+            variant="ghost"
+            onClick={() => onClick(route.to)}
+            className={cn(
+              "underline",
+              route.to === pathname
+                ? "text-green-500 hover:text-green-500"
+                : "text-black"
+            )}
+          >
+            {route.label}
+          </Button>
+        ))}
+        {pathname !== "/match-start" ? (
+          <div className="border-l-2 px-6 border-slate-300">
+            <Button
+              variant="success"
+              size="md"
+              onClick={() => onClick("/match-start")}
+              className="w-full"
+            >
+              <span>Play</span>
+              <ArrowRight className="size-6" />
+            </Button>
+          </div>
+        ) : null}
+      </nav>
+    </>
+  );
+};

--- a/src/presentation/components/share/navigation.tsx
+++ b/src/presentation/components/share/navigation.tsx
@@ -29,7 +29,7 @@ const routes = [
   },
   {
     to: "/users",
-    label: "Players",
+    label: "Users",
     Icon: Users,
   },
   {
@@ -77,7 +77,7 @@ export const Navigation = () => {
               </p>
             </div>
             <nav className="flex flex-col gap-y-2 pt-6">
-              {pathname !== "/match-start" ? (
+              {pathname !== "/match-start" && (
                 <div className="border-b-2 pb-2 border-slate-300">
                   <Button
                     variant="success"
@@ -89,7 +89,7 @@ export const Navigation = () => {
                     <ArrowRight className="size-8" />
                   </Button>
                 </div>
-              ) : null}
+              )}
               {routes.map((route) => (
                 <Button
                   key={route.to}
@@ -130,7 +130,7 @@ export const Navigation = () => {
             {route.label}
           </Button>
         ))}
-        {pathname !== "/match-start" ? (
+        {pathname !== "/match-start" && (
           <div className="border-l-2 px-6 border-slate-300">
             <Button
               variant="success"
@@ -142,7 +142,7 @@ export const Navigation = () => {
               <ArrowRight className="size-6" />
             </Button>
           </div>
-        ) : null}
+        )}
       </nav>
     </>
   );

--- a/src/presentation/pages/Match-start.tsx
+++ b/src/presentation/pages/Match-start.tsx
@@ -1,21 +1,14 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import axios from "axios";
-import { CirclePlus } from "lucide-react";
 
 import { PlayerCard } from "../components/match-start/player-card";
+import { Header } from "../components/share/header";
 
 import { Button } from "../shadcnUI/components/ui/button";
 import { ScrollArea } from "../shadcnUI/components/ui/scroll-area";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "../shadcnUI/components/ui/tooltip";
 
 import { cn } from "../shadcnUI/lib/utils";
-import { Logo } from "../components/share/logo";
 
 export const MatchStartPage = () => {
   const navigate = useNavigate();
@@ -141,43 +134,8 @@ export const MatchStartPage = () => {
   return (
     <>
       <div className="min-h-screen">
-        <div className="w-full flex justify-between border-b-2 mx-auto py-2">
-          <Link className="hover:text-transparent" to="/">
-            <div className="flex items-center">
-              <Logo size={8} />
-              <h1 className="text-2xl font-['Dela_Gothic_One'] [-webkit-text-stroke:1px_#fff462] pb-1">
-                Black Jack
-              </h1>
-            </div>
-          </Link>
-          <div>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="sm"
-                    variant="successOutline"
-                    className="uppercase rounded-full"
-                    asChild
-                  >
-                    <Link to="/users">
-                      <span className="hidden md:block">
-                        Add to Player List
-                      </span>
-
-                      <CirclePlus className="block md:hidden" size={24} />
-                    </Link>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <span className="text-base">Add to Player List</span>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
-        </div>
-
-        <div className="flex flex-col justify-center items-center min-h-screen WhiteDot">
+        <Header />
+        <div className="flex flex-col justify-center items-center min-h-screen WhiteDot pt-16">
           <div className="w-[70%] mt-2 mb-3 pt-2 p-4 bg-gradient-to-br from-green-400 via-green-500 to-green-400 rounded-xl border-2 border-neutral-300">
             <h2 className="text-xl font-bold text-black">
               Selected Players List
@@ -202,7 +160,7 @@ export const MatchStartPage = () => {
               </div>
             </ScrollArea>
           </div>
-          <div className="w-[70%] mt-2 mb-3 pt-2 p-4 bg-gradient-to-br from-neutral-100 via-neutral-300 to-neutral-100 rounded-xl border-2 border-neutral-300">
+          <div className="w-[70%] mt-2 mb-12 pt-2 p-4 bg-gradient-to-br from-neutral-100 via-neutral-300 to-neutral-100 rounded-xl border-2 border-neutral-300">
             <h2 className="text-xl font-bold text-black">
               Registered Players List
             </h2>
@@ -225,7 +183,7 @@ export const MatchStartPage = () => {
               </div>
             </ScrollArea>
           </div>
-          <div className="mt-6">
+          <div className="mt-6 fixed bottom-1 ">
             <div
               className={cn(
                 "border-2 border-yellow-500 rounded-md",

--- a/src/presentation/pages/Users.tsx
+++ b/src/presentation/pages/Users.tsx
@@ -1,0 +1,31 @@
+import { Header } from "../components/share/header";
+
+import { Input } from "../shadcnUI/components/ui/input";
+import { Label } from "../shadcnUI/components/ui/label";
+import { Button } from "../shadcnUI/components/ui/button";
+
+export const UsersPage = () => {
+  return (
+    <>
+      <div className="min-h-screen">
+        <Header />
+        <div className="flex flex-col items-center min-h-screen WhiteDot space-y-8 pt-6">
+          <div id="Hero" className="text-center text-black space-y-1 pt-16">
+            <h1 className="text-4xl md:text-5xl xl:text-6xl">Add to Player</h1>
+            <h3 className="text-xs sm:text-sm md:text-base font-medium">
+              Enter your username to start playing games
+            </h3>
+          </div>
+          {/* TODO: ユーザーの追加を行うフォームを実装 */}
+          <div id="input" className="flex flex-col space-y-4 w-[30%]">
+            <Label className="text-left text-black">Player Name</Label>
+            <Input className="rounded-md" placeholder="Player Name" />
+            <Button type="submit" variant="success">
+              Add
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/presentation/pages/Users.tsx
+++ b/src/presentation/pages/Users.tsx
@@ -11,15 +11,15 @@ export const UsersPage = () => {
         <Header />
         <div className="flex flex-col items-center min-h-screen WhiteDot space-y-8 pt-6">
           <div id="Hero" className="text-center text-black space-y-1 pt-16">
-            <h1 className="text-4xl md:text-5xl xl:text-6xl">Add to Player</h1>
+            <h1 className="text-4xl md:text-5xl xl:text-6xl">Add to User</h1>
             <h3 className="text-xs sm:text-sm md:text-base font-medium">
               Enter your username to start playing games
             </h3>
           </div>
           {/* TODO: ユーザーの追加を行うフォームを実装 */}
           <div id="input" className="flex flex-col space-y-4 w-[30%]">
-            <Label className="text-left text-black">Player Name</Label>
-            <Input className="rounded-md" placeholder="Player Name" />
+            <Label className="text-left text-black">User Name</Label>
+            <Input className="rounded-md" placeholder="User Name" />
             <Button type="submit" variant="success">
               Add
             </Button>

--- a/src/presentation/shadcnUI/components/ui/button.tsx
+++ b/src/presentation/shadcnUI/components/ui/button.tsx
@@ -33,10 +33,15 @@ const buttonVariants = cva(
           "bg-gradient-to-b from-neutral-50 via-neutral-200 to-neutral-300 text-indigo-600 hover:from-indigo-400 hover:via-indigo-600 hover:to-indigo-800 border-neutral-400 hover:border-indigo-900 hover:text-white border-b-4 border-x-2 active:border-b-0",
         locked:
           "bg-neutral-200 text-black hover:bg-neutral-300 border-neutral-400 border-b-4",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        ghost: "bg-transparent hover:bg-accent hover:text-accent-foreground",
+        transparent: "bg-transparent text-black hover:text-accent-foreground",
       },
       size: {
         default: "h-11 px-4 py-2",
         sm: "h-9 px-3",
+        md: "h-10 px-4",
         lg: "h-12 px-8",
         icon: "h-10 w-10",
         square: "size-32 rounded-md",

--- a/src/presentation/shadcnUI/components/ui/sheet.tsx
+++ b/src/presentation/shadcnUI/components/ui/sheet.tsx
@@ -1,0 +1,138 @@
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/presentation/shadcnUI/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      {children}
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}


### PR DESCRIPTION
# やったこと
- users画面
　- ゲーム用のユーザーを追加する画面を作成しました。
　- 共通ヘッダーを導入しました。
　- モバイル版ヘッダーも併せて作成しました。
- Match-start画面
  - 共通ヘッダーを適用しました。

# デモ
## users画
![スクリーンショット 2024-12-29 173904](https://github.com/user-attachments/assets/ffc93af9-582b-4c2e-86b4-7d6fa7234760)
![スクリーンショット 2024-12-29 173952](https://github.com/user-attachments/assets/72c08be8-ebeb-4ccd-abeb-0afbebe481aa)
![スクリーンショット 2024-12-29 174035](https://github.com/user-attachments/assets/ed3910d0-f9c5-4cd4-b9ac-e16a9f9ec43c)

## Match-start画
![スクリーンショット 2024-12-29 173919](https://github.com/user-attachments/assets/01de6583-9c2f-4170-aade-6509cfc4277f)
面

# 参考

