### PR TITLE
タイトルページのデザイン変更

### DIFF
--- a/src/presentation/components/title/Hero.tsx
+++ b/src/presentation/components/title/Hero.tsx
@@ -1,38 +1,24 @@
 export const Hero = () => {
   return (
     <>
-      <div className="max-w-3xl space-y-4">
-        <div className="relative inline-block z-0 w-full -space-y-3 md:-space-y-6">
+      <div className="max-w-3xl space-y-2 text-center">
+        <div className="relative inline-block z-0 w-full -space-y-3 md:-space-y-5">
           <h1
             className="
-              text-5xl md:text-6xl xl:text-7xl text-black font-['Dela_Gothic_One'] [-webkit-text-stroke:3px_#fff462]
-              before:md:block before:md:content-[''] before:md:absolute before:w-full
-              before:md:h-10 before:md:bg-black before:md:mt-6 before:md:-z-10
-              after:md:block after:md:content-[''] after:md:absolute after:md:w-full
-            after:md:bg-black after:md:-mt-2 after:md:-z-10 after:md:border-solid
-              after:md:border-t-[12px] after:md:border-t-black
-              after:md:border-l-[16px] after:md:border-l-white
-              after:md:border-r-[16px] after:md:border-r-white
+              text-5xl md:text-6xl xl:text-7xl text-black font-['Dela_Gothic_One'] [-webkit-text-stroke:3px_#fff462] tracking-wide
             "
           >
             BLACK
           </h1>
           <h1
             className="
-              text-5xl md:text-6xl xl:text-7xl text-black font-['Dela_Gothic_One'] [-webkit-text-stroke:3px_#fff462]
-              before:md:block before:md:content-[''] before:md:absolute before:md:w-full
-              before:md:h-9 before:md:bg-black before:md:mt-6 before:md:-z-10
-              after:md:block after:md:content-[''] after:md:absolute after:md:w-full
-            after:md:bg-black after:md:-mt-2 after:md:-z-10 after:md:border-solid
-              after:md:border-t-[12px] after:md:border-t-black
-              after:md:border-l-[16px] after:md:border-l-white
-              after:md:border-r-[16px] after:md:border-r-white
+              text-5xl md:text-6xl xl:text-7xl text-black font-['Dela_Gothic_One'] [-webkit-text-stroke:3px_#fff462] tracking-wide
             "
           >
             JACK
           </h1>
         </div>
-        <h3 className="text-base sm:text-xl md:text-2xl font-medium">
+        <h3 className="text-sm sm:text-base md:text-xl font-medium">
           Welcome to the Black Jack game! <br />
           Click the button below to start playing.
         </h3>

--- a/src/presentation/components/title/TitleButton.tsx
+++ b/src/presentation/components/title/TitleButton.tsx
@@ -8,33 +8,28 @@ interface TitleButtonProps {
   to: string;
   text: string;
   icon: LucideIcon;
-  buttonSize?: string;
   direction?: string;
-  iconSize?: string;
+  variant?: "success" | "successOutline";
 }
 
 export const TitleButton = ({
   to,
   text,
   icon: Icon,
-  // 正方形のボタンを基準
-  buttonSize = "md:size-32",
-  direction = "flex-col",
-  iconSize = "size-20",
+  direction = "flex-row",
+  variant = "success",
 }: TitleButtonProps) => {
   return (
     <>
       <Button
-        className={cn(
-          "group relative py-6 px-10 w-40 transition hover:scale-110",
-          buttonSize
-        )}
+        variant={variant}
+        className="group relative py-6 px-10 w-40 md:w-48 transition hover:scale-110 transform duration-500"
         asChild
       >
-        <Link className={cn("flex", direction)} to={to}>
-          <Icon className={cn("hidden md:block", iconSize)} />
+        <Link className={cn("flex hover:text-white", direction)} to={to}>
+          <Icon className="hidden md:block size-8" />
           <span className="text-base md:text-xl">{text}</span>
-          <div className="absolute inset-0 flex h-full w-full justify-center [transform:skew(-15deg)_translateX(-100%)] group-hover:duration-1000 group-hover:[transform:skew(-12deg)_translateX(100%)]">
+          <div className="absolute inset-0 flex h-full w-full justify-center [transform:skew(-15deg)_translateX(-50%)] group-hover:duration-1000 group-hover:[transform:skew(-12deg)_translateX(50%)]">
             <div className="relative h-full w-8 bg-white/20" />
           </div>
         </Link>

--- a/src/presentation/pages/Title.tsx
+++ b/src/presentation/pages/Title.tsx
@@ -1,34 +1,203 @@
+import { motion } from "framer-motion";
 import { ArrowRight, Users, BookOpenText, ChartColumn } from "lucide-react";
 
 import { Logo } from "../components/share/logo";
 import { Hero } from "../components/title/Hero";
 import { TitleButton } from "../components/title/TitleButton";
 
+const cards = [
+  "/trump/heartA.png",
+  "/trump/back.png",
+  "/trump/heart2.png",
+  "/trump/back.png",
+  "/trump/heart3.png",
+  "/trump/back.png",
+  "/trump/heart4.png",
+  "/trump/back.png",
+  "/trump/heart5.png",
+  "/trump/back.png",
+  "/trump/heart6.png",
+  "/trump/back.png",
+  "/trump/heart7.png",
+  "/trump/back.png",
+  "/trump/heart8.png",
+  "/trump/back.png",
+  "/trump/heart9.png",
+  "/trump/back.png",
+  "/trump/heart10.png",
+  "/trump/back.png",
+  "/trump/heartJ.png",
+  "/trump/back.png",
+  "/trump/heartQ.png",
+  "/trump/back.png",
+  "/trump/heartK.png",
+  "/trump/back.png",
+  "/trump/diamondA.png",
+  "/trump/back.png",
+  "/trump/diamond2.png",
+  "/trump/back.png",
+  "/trump/diamond3.png",
+  "/trump/back.png",
+  "/trump/diamond4.png",
+  "/trump/back.png",
+  "/trump/diamond5.png",
+  "/trump/back.png",
+  "/trump/diamond6.png",
+  "/trump/back.png",
+  "/trump/diamond7.png",
+  "/trump/back.png",
+  "/trump/diamond8.png",
+  "/trump/back.png",
+  "/trump/diamond9.png",
+  "/trump/back.png",
+  "/trump/diamond10.png",
+  "/trump/back.png",
+  "/trump/diamondJ.png",
+  "/trump/back.png",
+  "/trump/diamondQ.png",
+  "/trump/back.png",
+  "/trump/diamondK.png",
+  "/trump/back.png",
+  "/trump/spadeA.png",
+  "/trump/back.png",
+  "/trump/spade2.png",
+  "/trump/back.png",
+  "/trump/spade3.png",
+  "/trump/back.png",
+  "/trump/spade4.png",
+  "/trump/back.png",
+  "/trump/spade5.png",
+  "/trump/back.png",
+  "/trump/spade6.png",
+  "/trump/back.png",
+  "/trump/spade7.png",
+  "/trump/back.png",
+  "/trump/spade8.png",
+  "/trump/back.png",
+  "/trump/spade9.png",
+  "/trump/back.png",
+  "/trump/spade10.png",
+  "/trump/back.png",
+  "/trump/spadeJ.png",
+  "/trump/back.png",
+  "/trump/spadeQ.png",
+  "/trump/back.png",
+  "/trump/spadeK.png",
+  "/trump/back.png",
+  "/trump/clubA.png",
+  "/trump/back.png",
+  "/trump/club2.png",
+  "/trump/back.png",
+  "/trump/club3.png",
+  "/trump/back.png",
+  "/trump/club4.png",
+  "/trump/back.png",
+  "/trump/club5.png",
+  "/trump/back.png",
+  "/trump/club6.png",
+  "/trump/back.png",
+  "/trump/club7.png",
+  "/trump/back.png",
+  "/trump/club8.png",
+  "/trump/back.png",
+  "/trump/club9.png",
+  "/trump/back.png",
+  "/trump/club10.png",
+  "/trump/back.png",
+  "/trump/clubJ.png",
+  "/trump/back.png",
+  "/trump/clubQ.png",
+  "/trump/back.png",
+  "/trump/clubK.png",
+  "/trump/back.png",
+];
+
+const generateRandomStyle = () => ({
+  top: `${Math.random() * 100}vh`,
+  left: `${Math.random() * 100}vw`,
+  rotate: `${Math.random() * 360}deg`,
+  scale: Math.random() * 0.5 + 0.5,
+});
+
 export const TitlePage = () => {
   return (
-    <main className="min-h-screen">
-      <div className="hidden absolute top-4 left-4 md:block items-center">
-        <Logo size={32} />
-      </div>
-
-      <div className="min-h-full flex flex-col items-center justify-center text-center gap-y-4 flex-1 px-6 pt-16 pb-10">
-        <Hero />
-        <div className="space-y-4 md:space-y-8">
-          <TitleButton
-            to="match-start"
-            text="Play"
-            icon={ArrowRight}
-            buttonSize="md:w-48"
-            direction="flex-row-reverse"
-            iconSize="size-8"
-          />
-          <div className="flex flex-col justify-center md:flex-row space-y-4 md:space-y-0 md:space-x-52">
-            <TitleButton to="/scores" text="スコア" icon={ChartColumn} />
-            <TitleButton to="/users" text="プレイヤー登録" icon={Users} />
-            <TitleButton to="/rules" text="遊び方" icon={BookOpenText} />
+    <>
+      <div className="min-h-screen relative overflow-hidden">
+        <div className="min-h-screen grid grid-cols-1 md:grid-cols-2 WhiteDot z-0">
+          <div className="min-h-screen hidden md:block z-20">
+            <div className="h-[85vh] bg-gradient-to-t from-green-400/90 via-green-500 to-green-400/90 hidden md:flex items-center justify-center m-9 rounded-lg">
+              <motion.div
+                key="logo"
+                initial={{ rotate: 0 }}
+                animate={{ rotate: 720 }}
+                transition={{ duration: 1 }}
+                className="pt-2"
+              >
+                <Logo size={60} />
+              </motion.div>
+            </div>
+          </div>
+          <div className="min-h-screen relative md:flex flex-col items-center px-4 z-20 bg-neutral-50/80">
+            <motion.div
+              key="title"
+              initial={{ y: -50, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              transition={{
+                type: "spring",
+                damping: 5,
+                stiffness: 40,
+                restDelta: 0.001,
+                duration: 0.3,
+              }}
+            >
+              <div className="pt-12">
+                <Hero />
+              </div>
+              <div className="flex flex-col items-center space-y-2 md:space-y-4 pt-2">
+                <TitleButton
+                  to="match-start"
+                  text="Play"
+                  icon={ArrowRight}
+                  direction="flex-row-reverse"
+                />
+                <TitleButton
+                  to="/users"
+                  text="Add a Player"
+                  icon={Users}
+                  variant="successOutline"
+                />
+                <TitleButton
+                  to="/scores"
+                  text="Score"
+                  icon={ChartColumn}
+                  variant="successOutline"
+                />
+                <TitleButton
+                  to="/rules"
+                  text="How to PLay"
+                  icon={BookOpenText}
+                  variant="successOutline"
+                />
+              </div>
+            </motion.div>
           </div>
         </div>
+        {cards.map((card, index) => (
+          <motion.img
+            key={index}
+            src={card}
+            alt="playing-card"
+            className="absolute rounded-md h-28 z-10"
+            style={generateRandomStyle()}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{
+              delay: index * 0.01,
+              duration: 0.1,
+            }}
+          />
+        ))}
       </div>
-    </main>
+    </>
   );
 };

--- a/src/presentation/pages/Title.tsx
+++ b/src/presentation/pages/Title.tsx
@@ -162,7 +162,7 @@ export const TitlePage = () => {
                 />
                 <TitleButton
                   to="/users"
-                  text="Add a Player"
+                  text="Register User"
                   icon={Users}
                   variant="successOutline"
                 />
@@ -174,7 +174,7 @@ export const TitlePage = () => {
                 />
                 <TitleButton
                   to="/rules"
-                  text="How to PLay"
+                  text="How to Play"
                   icon={BookOpenText}
                   variant="successOutline"
                 />


### PR DESCRIPTION
# やったこと
- Title画面
　- 表示文言を英語で統一しました
　　- ただし、遊び方画面に日本語を残すことが想定されるため、英語に統一しなくてもよかったかもしれません。
　- title画面のデザインを修正
　　- 当初は背景で3Dモデルを回転させる予定でしたが、さまざまな都合等で断念したため、Framer Motionを活用してデザインを再構築しました。


# デモ
![スクリーンショット 2024-12-29 175240](https://github.com/user-attachments/assets/685e1b9e-18a0-4784-8288-7967e80a4b0d)

https://github.com/user-attachments/assets/466ef822-8487-407f-8959-6a862c89a960



# 参考

