### PR TITLE
ラウンド完了後に MatchGetSummary API が呼び出されてもエラーにならないように修正

### DIFF
--- a/src/application/matches/getSummary/matchGetSummaryResultDealer.ts
+++ b/src/application/matches/getSummary/matchGetSummaryResultDealer.ts
@@ -20,8 +20,8 @@ export class MatchGetSummaryResultDealer implements DealerNotification {
    *
    * @param upCard アップカード
    */
-  public notifyUpCard(upCard: Card): void {
+  public notifyUpCard(upCard?: Card): void {
     this.upCard = upCard;
-    this.upCardSoftTotal = upCard.getSoftPoint();
+    this.upCardSoftTotal = upCard?.getSoftPoint();
   }
 }

--- a/src/domain/models/dealers/dealer.ts
+++ b/src/domain/models/dealers/dealer.ts
@@ -58,8 +58,8 @@ export class Dealer {
    *
    * @returns アップカード
    */
-  public getUpCard(): Card {
-    return this.hand.getCards()[0];
+  public getUpCard(): Card | undefined {
+    return this.hand.getCards().at(0);
   }
 
   /**

--- a/src/domain/models/dealers/dealerNotification.ts
+++ b/src/domain/models/dealers/dealerNotification.ts
@@ -9,5 +9,5 @@ export interface DealerNotification {
    *
    * @param upCard アップカード
    */
-  notifyUpCard(upCard: Card): void;
+  notifyUpCard(upCard?: Card): void;
 }


### PR DESCRIPTION
元々、MatchGetSummary API はラウンド完了後には呼び出さない想定でした。ですが、おそらくラウンド数取得などのために、ラウンド完了後も呼び出しが必要だったのではないかと思います。

ラウンド完了後に呼び出された場合、ディーラーのハンドは既にディスカードされており、アップカードが取得できないため、エラーが発生していました。

![image](https://github.com/user-attachments/assets/71a25215-a901-4889-a2e7-849ff8e30fbc)

もう少し API を分割しても良かったのかもしれませんが、とりあえず、ディーラーのハンドがない状態で MatchGetSummary API が呼び出された場合には、アップカードとそのソフトトータルとして `undefined` を返すように修正しました。